### PR TITLE
Would like as much of the instructions in single doc as possible

### DIFF
--- a/docs/tutorials/how_to_yocto/index.rst
+++ b/docs/tutorials/how_to_yocto/index.rst
@@ -6,7 +6,7 @@ Steps to build EVerest in a Yocto image
 =======================================
 
 #. Set up a Yocto development environment.
-
+TODO: Create more hand-holding steps, since it is not obvious what will need to be followed exactly and what won't.
    .. TIP::
       The `Yocto Project Quick Build`_ guide is an excellent place to start.
 


### PR DESCRIPTION
Between text in the Yocto Party chat and generic Yocto docs, there was a lot of bouncing around trying to follow the steps.

Ideally the docs would be a one-stop shop, especially for people who don't want to have Yocto left as an exercise but can just follow some steps to get a simple example set up.

Step 1 and 2 essentially say that you can figure out Yocto on your own, with some links as a guide, but it would be nice to instead give the handful of instructions that could get someone on their way instead of letting them figure out that they need to substitute some arguments in some cases and ignore other parts.

Other changes:
- mention that bitbake needs to be in the path. See https://gist.github.com/folkengine/0189bb7371461a730456809650330cca as an example
- The Samba setup instructions should say that the workdir needs to be chowned to 1000:1000 before running the docker command. 
- To run qemu: ```runqemu qemux86-64 slirp nographic``` which allows docker to handle networking to avoid issues with /dev/net/tun and to run without requiring X11/SDL.