### PR TITLE
Add a compilable out-of-tree SerialIO module skeleton

### DIFF
--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/.clang-format
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/.clang-format
@@ -1,0 +1,138 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/.eslintrc.json
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/.eslintrc.json
@@ -1,0 +1,43 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es2021": true
+    },
+    "extends": [
+        "airbnb-base"
+    ],
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
+    "rules": {
+        "camelcase": "off",
+        "eqeqeq": [
+            "error",
+            "smart"
+        ],
+        "comma-dangle": [
+            "warn",
+            {
+                "objects": "always-multiline",
+                "arrays": "always-multiline",
+                "functions": "never"
+            }
+        ],
+        "import/no-unresolved": [
+            2,
+            {
+                "ignore": [
+                    "everestjs"
+                ]
+            }
+        ],
+        "max-len": [
+            "warn",
+            {
+                "code": 120,
+                "tabWidth": 2
+            }
+        ]
+    }
+}

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/CMakeLists.txt
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.14.7)
+project(everest-tutorial VERSION 0.1
+    DESCRIPTION "EVerest tutorial modules"
+    LANGUAGES CXX C)
+
+find_package(everest-cmake 0.1 REQUIRED
+    COMPONENTS bundling
+    PATHS ../everest-cmake)
+
+# options
+option(BUILD_TESTING "Run unit tests" OFF)
+option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
+
+# dependencies
+if (NOT DISABLE_EDM)
+    evc_setup_edm()
+else()
+    find_package(everest-core)
+    # InfyPowerACDC uses pal-sigslot
+    find_package(PalSigslot REQUIRED)
+endif()
+
+ev_add_project()
+
+# config (not needed if you do not need a run script for your configuration)
+# add_subdirectory(config)
+
+# configure clang-tidy if requested
+if(CMAKE_RUN_CLANG_TIDY)
+    message("Enabling clang-tidy")
+    set(CMAKE_CXX_CLANG_TIDY clang-tidy)
+endif()
+
+# testing
+if(BUILD_TESTING)
+    include(CTest)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+    evc_include(CodeCoverage)
+    append_coverage_compiler_flags()
+    add_subdirectory(tests)
+    setup_target_for_coverage_gcovr_html(
+        NAME gcovr_coverage
+        EXECUTABLE test_config
+        DEPENDENCIES test_config everest
+    )
+    setup_target_for_coverage_lcov(
+        NAME lcov_coverage
+        EXECUTABLE test_config
+        DEPENDENCIES test_config everest
+    )
+endif()

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/config/config-serial-io.yaml
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/config/config-serial-io.yaml
@@ -1,0 +1,9 @@
+settings:
+  telemetry_enabled: true
+
+active_modules:
+  serial_io:
+    module: SerialIO
+    config_module:
+      read_device: /tmp/vserial1
+      write_device: /tmp/vserial2

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/dependencies.yaml
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/dependencies.yaml
@@ -1,0 +1,4 @@
+---
+everest-core:
+  git: git@github.com:EVerest/everest-core.git
+  git_tag: main

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/interfaces/serial_io.yaml
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/interfaces/serial_io.yaml
@@ -1,0 +1,21 @@
+description: Support basic read and write access to a serial device.
+cmds:
+  read:
+    description: Read content from a serial device.
+    result:
+      description: The UTF-8-encoded bytes read from a serial device.
+      type: string
+
+  write:
+    description: Write content to a serial device.
+    arguments:
+      bytes:
+        description:
+          A UTF-8-encoded string to be decoded and written to a serial device.
+        type: string
+    result:
+      description: >-
+        The result of writing to the serial device. This should indicate
+        success or provide information on an error encountered during the write
+        process.
+      type: string

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/CMakeLists.txt
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/CMakeLists.txt
@@ -1,0 +1,1 @@
+ev_add_module(SerialIO)

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/CMakeLists.txt
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "serial_io/serial_ioImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/SerialIO.cpp
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/SerialIO.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "SerialIO.hpp"
+
+namespace module {
+
+void SerialIO::init() {
+    invoke_init(*p_serial_io);
+}
+
+void SerialIO::ready() {
+    invoke_ready(*p_serial_io);
+}
+
+} // namespace module

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/SerialIO.hpp
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/SerialIO.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef SERIAL_IO_HPP
+#define SERIAL_IO_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/serial_io/Implementation.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {
+    std::string read_device;
+    std::string write_device;
+    bool flush_on_read;
+};
+
+class SerialIO : public Everest::ModuleBase {
+public:
+    SerialIO() = delete;
+    SerialIO(const ModuleInfo& info, std::unique_ptr<serial_ioImplBase> p_serial_io, Conf& config) :
+        ModuleBase(info), p_serial_io(std::move(p_serial_io)), config(config){};
+
+    const std::unique_ptr<serial_ioImplBase> p_serial_io;
+    const Conf& config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // SERIAL_IO_HPP

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/doc.rst
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/doc.rst
@@ -1,0 +1,22 @@
+.. _everest_modules_handwritten_SerialIO:
+
+..  This file is a placeholder for an optional single file
+    handwritten documentation for the SerialIO module.
+    Please decide whether you want to use this single file,
+    or a set of files in the doc/ directory.
+    In the latter case, you can delete this file.
+    In the former case, you can delete the doc/ directory.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete this file
+    and the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+
+*******************************************
+SerialIO
+*******************************************
+
+:ref:`Link <everest_modules_SerialIO>` to the module's reference.
+Read to and write from a serial device on demand.

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/docs/index.rst
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/docs/index.rst
@@ -1,0 +1,23 @@
+.. _everest_modules_handwritten_SerialIO:
+
+..  This file is a placeholder for optional multiple files
+    handwritten documentation for the SerialIO module.
+    Please decide whether you want to use the doc.rst file
+    or a set of files in the doc/ directory.
+    In the latter case, you can delete the doc.rst file.
+    In the former case, you can delete the doc/ directory.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete this file
+    and the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+    This index.rst file is the entry point for the module documentation.
+
+*******************************************
+SerialIO
+*******************************************
+
+:ref:`Link <everest_modules_SerialIO>` to the module's reference.
+Read to and write from a serial device on demand.

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/manifest.yaml
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/manifest.yaml
@@ -1,0 +1,31 @@
+description:
+  Read to and write from a serial device on demand.
+
+metadata:
+  license: https://spdx.org/licenses/Apache-2.0.html
+  authors:
+    - Edith Clarke, Energetic Engineering LLC
+
+config:
+  read_device:
+    description: >-
+      The terminal device file to read from.
+    type: string
+
+  write_device:
+    description: >-
+      The terminal device file to write to.
+    type: string
+
+  flush_on_read:
+    description: >-
+      Whether to flush the read_device file buffer after a successful read
+      command.
+    type: boolean
+    default: true
+
+provides:
+  serial_io:
+    interface: serial_io
+    description:
+      A simple module allowing for reading to and writing from a serial device.

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/serial_io/serial_ioImpl.cpp
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/serial_io/serial_ioImpl.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "serial_ioImpl.hpp"
+
+namespace module {
+namespace serial_io {
+
+void serial_ioImpl::init() {
+}
+
+void serial_ioImpl::ready() {
+}
+
+std::string serial_ioImpl::handle_read() {
+    // your code for cmd read goes here
+    return "everest";
+}
+
+std::string serial_ioImpl::handle_write(std::string& bytes) {
+    // your code for cmd write goes here
+    return "everest";
+}
+
+} // namespace serial_io
+} // namespace module

--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/serial_io/serial_ioImpl.hpp
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/modules/SerialIO/serial_io/serial_ioImpl.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef SERIAL_IO_SERIAL_IO_IMPL_HPP
+#define SERIAL_IO_SERIAL_IO_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/serial_io/Implementation.hpp>
+
+#include "../SerialIO.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace serial_io {
+
+struct Conf {};
+
+class serial_ioImpl : public serial_ioImplBase {
+public:
+    serial_ioImpl() = delete;
+    serial_ioImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<SerialIO>& mod, Conf& config) :
+        serial_ioImplBase(ev, "serial_io"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // command handler functions (virtual)
+    virtual std::string handle_read() override;
+    virtual std::string handle_write(std::string& bytes) override;
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<SerialIO>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace serial_io
+} // namespace module
+
+#endif // SERIAL_IO_SERIAL_IO_IMPL_HPP


### PR DESCRIPTION
Incorporate a custom example module called `SerialIO` into the Yocto tutorial. This module includes a custom interface for communicating with a serial device that will be used in subsequent expansions to this tutorial.

This also serves as a self-contained working example of how to create a third-party module and build it against EVerest, complementing the ["How To: Develop New Modules" tutorial](https://everest.github.io/nightly/tutorials/new_modules/index.html). The build process is identical to the one described in the latter tutorial. Assuming

- `$EVEREST_WORKSPACE` is a directory containing `everest-cmake` (and other dependent repositories) as child subdirectories and
- `$EVEREST_TUTORIAL_DIR` is the path to the `custom-everest-content` directory in this PR,

the `SerialIO` module CMake project can configured as follows:

```bash
export CMAKE_PREFIX_PATH="${EVEREST_WORKSPACE}" \
       TUTORIAL_INSTALL_PREFIX="${EVEREST_TUTORIAL_DIR}/build/dist"

cd "${EVEREST_TUTORIAL_DIR}/build"
cmake --install-prefix "${TUTORIAL_INSTALL_PREFIX}" ..
```

Assuming CMake executed successfully, the module can be compiled and installed into `${TUTORIAL_INSTALL_PREFIX}` using Make:

```bash
make -j$(nproc) && make install -j$(nproc)
```

> [!IMPORTANT]
> Some of EVerest's dependencies can attempt to install themselves into unexpected places on your system. (Josev has been an offender in my experience.)
>
> If you are experiencing errors when calling `make install` and are developing in a sandbox environment like an [`everest-playground`-based Docker container from `everest-utils`](https://github.com/EVerest/everest-utils/tree/35a444683f9e15699066d704bd31d533cc7bebd8/docker), consider running `make install` as root.