### PR TITLE
dependencies.yaml: use https instead of ssh.

### DIFF
--- a/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/dependencies.yaml
+++ b/docs/tutorials/how_to_yocto/tutorial-code/custom-everest-content/dependencies.yaml
@@ -1,4 +1,4 @@
 ---
 everest-core:
-  git: git@github.com:EVerest/everest-core.git
+  git: https://github.com/EVerest/everest-core.git
   git_tag: main


### PR DESCRIPTION
When running in a devcontainer, vscode is able to forward git https auth from the host automatically. ssh requires further configuration, and `edm` will fail to fetch dependencies.
see: https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials